### PR TITLE
Remove infinite redirect when token expires

### DIFF
--- a/frontend/src/components/ProtectedRoute/ProtectedRoute.js
+++ b/frontend/src/components/ProtectedRoute/ProtectedRoute.js
@@ -33,6 +33,7 @@ export default function ProtectedRoute(ComponentToProtect) {
                     }
                 })
                 .catch(err => {
+                    cookies.remove('token');
                     this.setState({ loading: false, redirect: true });
                 });
         }


### PR DESCRIPTION
Behavior: `/api/user/whoami` is called on page load, it sees that token exists, but it has expired and returns a `401` error and the frontend handles the error by redirecting to '/' which again fires `/api/user/whoami` resulting in infinite redirects/calls happening. 

Solution : I have removed the token from cookies when `/api/user/whoami` results in an error.